### PR TITLE
Added EnableProjectHarvesting to Install.wixproj

### DIFF
--- a/msvs/RedisWatcher/Install/Install.wixproj
+++ b/msvs/RedisWatcher/Install/Install.wixproj
@@ -10,6 +10,7 @@
     <OutputType>Package</OutputType>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
+    <EnableProjectHarvesting>True</EnableProjectHarvesting>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>


### PR DESCRIPTION
In order to be compatible with wix 3.6 EnableProjectHarvesting has to be added to the PropertyGroup of the Install.wixproj, otherwise compilation will fail with errormessage:

LGHT0094: Unresolved reference to symbol 'WixComponentGroup:Product.Generated' in section 'Product:*'
