### PR TITLE
Using iswspace and iswprint to allow multi-byte characters

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -420,7 +420,7 @@ sds sdscatrepr(sds s, char *p, size_t len) {
         case '\a': s = sdscatlen(s,"\\a",2); break;
         case '\b': s = sdscatlen(s,"\\b",2); break;
         default:
-            if (isprint(*p))
+            if (iswprint(*p))
                 s = sdscatprintf(s,"%c",*p);
             else
                 s = sdscatprintf(s,"\\x%02x",(unsigned char)*p);
@@ -482,7 +482,7 @@ sds *sdssplitargs(char *line, int *argc) {
     *argc = 0;
     while(1) {
         /* skip blanks */
-        while(*p && isspace(*p)) p++;
+        while(*p && iswspace(*p)) p++;
         if (*p) {
             /* get a token */
             int inq=0;  /* set to 1 if we are in "quotes" */


### PR DESCRIPTION
Using commands which contains multi-byte characters fails because isprint and isspace is used. This commit uses iswprint and iswspace to allow wide characters. Before, the following commands would fail:

SET öl 1
GET öl
KEYS *

When connecting the updated CLI to a server with isspace/isprint the output of mutli-byte characters is garbage. What should I do about that? Try to convert it them to hex? Maybe this is not the correct fix at all.

This is now fixed. Let me know if this PR is OK and i'll fix it in the other branches as well.

I tried to find the CLA but http://www.microsoft.com/web/webpi/eula/MSOpenTech_CLA.rtf is broken.
