### PR TITLE
Fixed AOF growth calculation overflow

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1061,14 +1061,13 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
              server.aof_rewrite_perc &&
              server.aof_current_size > server.aof_rewrite_min_size)
          {
-            long long base = server.aof_rewrite_base_size ?
-                            server.aof_rewrite_base_size : 1;
-            long long growth = (server.aof_current_size*100/base) - 100;
-            if (growth >= server.aof_rewrite_perc) {
-                redisLog(REDIS_NOTICE,"Starting automatic rewriting of AOF on %lld%% growth",growth);
-                rewriteAppendOnlyFileBackground();
-            }
-         }
+			 off_t base = server.aof_rewrite_base_size ? server.aof_rewrite_base_size : 1;
+			 float growth = (1.0 * (server.aof_current_size - base)) / base * 100;
+			 if (growth >= server.aof_rewrite_perc) {
+				 redisLog(REDIS_NOTICE,"Starting automatic rewriting of AOF on %.2f%% growth", growth);
+				 rewriteAppendOnlyFileBackground();
+			 }
+		 }
     }
 
 


### PR DESCRIPTION
Fixed an overflow the AOF growth calculation that prevents the automatic rewriting of the log file when it becomes too big:

Before:

``` c
long long base = server.aof_rewrite_base_size ? 
    server.aof_rewrite_base_size : 1;
long long growth = (server.aof_current_size*100/base) - 100;
if (growth >= server.aof_rewrite_perc) {
    //rewrite append only file
}
```

_server.aof_current_size_ is of type _off_t_;
assuming that _server.aof_current_size_ is, for example 83886080, multiplying it for 100 will cause an overflow, the result of the entire expression will be a negative number and the AOF rewrite will be never triggered.
