### PR TITLE
BUGFIX: remove extra '}' in hiredis/net.c

### DIFF
--- a/deps/hiredis/net.c
+++ b/deps/hiredis/net.c
@@ -123,7 +123,6 @@ static int redisCreateSocket(redisContext *c, int type) {
     }
     return s;
 }
-}
 #endif
 
 


### PR DESCRIPTION
This is fix compiling error on OS X

net.c:126:1: error: extraneous closing brace ('}')
}
