### PR TITLE
Update RedisWatcher Install.wixproj to be compatible with WiX Toolset v3.6 or greater

### DIFF
--- a/msvs/RedisWatcher/Install/Install.wixproj
+++ b/msvs/RedisWatcher/Install/Install.wixproj
@@ -10,6 +10,7 @@
     <OutputType>Package</OutputType>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
+    <EnableProjectHarvesting>True</EnableProjectHarvesting>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>


### PR DESCRIPTION
When trying to compile RedisWatcher with WiX Toolset v3.6 or greater, I run into this error:

**Description**: Unresolved reference to symbol 'WixComponentGroup:Product.Generated' in section 'Product:{3404A743-6802-41DD-A0BD-9229827FD2AF}'.
**File**: ~\redis\msvs\RedisWatcher\Install\Product.wxs
**Line**: 37
**Column**: 1
**Project**: Install

This pull request updates RedisWatcher to be compatible with WiX Toolset v3.6 or greater (tested wtih v3.8).

Got the solution from here: http://stackoverflow.com/a/12741595/3058685
