### PR TITLE
Fix VC++ compiler warning C4005

### DIFF
--- a/deps/hiredis/sds.h
+++ b/deps/hiredis/sds.h
@@ -36,7 +36,9 @@
 
 #ifdef _WIN32
   #define inline __inline
-  #define va_copy(d,s) d = (s)
+  #if defined(_MSC_VER) && (_MSC_VER < 1800)
+    #define va_copy(d,s) d = (s)
+  #endif
 #endif
 
 typedef char *sds;


### PR DESCRIPTION
This commit fixes redefinition of va_copy under Visual Studio 2013.
