### PR TITLE
Issue 173: add child process log messages to main log file

### DIFF
--- a/src/Win32_Interop/Win32_QFork.cpp
+++ b/src/Win32_Interop/Win32_QFork.cpp
@@ -820,7 +820,7 @@ BOOL QForkShutdown() {
     return TRUE;
 }
 
-BOOL BeginForkOperation(OperationType type, char* fileName, LPVOID globalData, int sizeOfGlobalData, DWORD* childPID, uint32_t dictHashSeed) {
+BOOL BeginForkOperation(OperationType type, char* fileName, LPVOID globalData, int sizeOfGlobalData, DWORD* childPID, uint32_t dictHashSeed, char* logfile) {
     try {
         // copy operation data
         g_pQForkControl->typeOfOperation = type;
@@ -906,7 +906,17 @@ BOOL BeginForkOperation(OperationType type, char* fileName, LPVOID globalData, i
         char arguments[_MAX_PATH];
         memset(arguments,0,_MAX_PATH);
         PROCESS_INFORMATION pi;
-        sprintf_s(arguments, _MAX_PATH, "\"%s\" --%s %llu %lu", fileName, cQFork.c_str(), (uint64_t)g_hQForkControlFileMap, GetCurrentProcessId());
+        sprintf_s(
+            arguments,
+            _MAX_PATH,
+            "\"%s\" --%s %llu %lu --%s \"%s\"",
+            fileName,
+            cQFork.c_str(),
+            (uint64_t)g_hQForkControlFileMap,
+            GetCurrentProcessId(),
+            cLogfile.c_str(),
+            (logfile != NULL && logfile[0] != '\0') ? logfile : "stdout");
+        
         if (FALSE == CreateProcessA(fileName, arguments, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {
             throw system_error( 
                 GetLastError(),

--- a/src/Win32_Interop/Win32_QFork.h
+++ b/src/Win32_Interop/Win32_QFork.h
@@ -59,7 +59,7 @@ StartupStatus QForkStartup(int argc, char** argv);
 BOOL QForkShutdown();
 
 // For master process use only
-BOOL BeginForkOperation(OperationType type, char* fileName, LPVOID globalData, int sizeOfGlobalData, DWORD* childPID, unsigned __int32 dictHashSeed);
+BOOL BeginForkOperation(OperationType type, char* fileName, LPVOID globalData, int sizeOfGlobalData, DWORD* childPID, unsigned __int32 dictHashSeed, char* logfile);
 OperationStatus GetForkOperationStatus();
 BOOL EndForkOperation(int * pExitCode); 
 BOOL AbortForkOperation();

--- a/src/aof.c
+++ b/src/aof.c
@@ -1119,7 +1119,7 @@ int rewriteAppendOnlyFileBackground(void) {
     start = ustime();
 
     snprintf(tmpfile,256,"temp-rewriteaof-bg-%d.aof", (int) getpid());
-    if (BeginForkOperation(otAOF, tmpfile, &server, sizeof(server), &server.aof_child_pid, dictGetHashFunctionSeed()) == FALSE) {
+    if (BeginForkOperation(otAOF, tmpfile, &server, sizeof(server), &server.aof_child_pid, dictGetHashFunctionSeed(), server.logfile) == FALSE) {
             redisLog(REDIS_WARNING,
                 "Can't rewrite append only file in background: fork: %s",
                 strerror(errno));

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -743,7 +743,7 @@ int rdbSaveBackground(char *filename) {
     long long start;
     start = ustime();
 	server.dirty_before_bgsave = server.dirty;
-	if (BeginForkOperation(otRDB, filename, &server, sizeof(server), &server.rdb_child_pid, dictGetHashFunctionSeed())) {
+	if (BeginForkOperation(otRDB, filename, &server, sizeof(server), &server.rdb_child_pid, dictGetHashFunctionSeed(), server.logfile)) {
         server.stat_fork_time = ustime()-start;
         updateDictResizePolicy();
         return REDIS_OK;

--- a/src/redisLog.h
+++ b/src/redisLog.h
@@ -28,7 +28,12 @@
 #define REDIS_WARNING 3
 #define REDIS_LOG_RAW (1<<10) /* Modifier to log without timestamp */
 #define REDIS_DEFAULT_VERBOSITY REDIS_NOTICE
-#define REDIS_MAX_LOGMSG_LEN    1024 /* Default maximum length of syslog messages */
+/*
+ * Default maximum length of syslog messages.
+ * Empirical results show that 1024 is also the maximum size that WriteFile can
+ * write atomically.
+ */
+#define REDIS_MAX_LOGMSG_LEN    1024
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Slave processes were not using the master process log file.
On Unix this is relying on the server.logfile variable being available
to the slave processes through fork(), and reopening the logfile
in the slaves (on every log event).
On Windows we don't use server.logfile and require an explicity call
to setLogFile.
I resorted to explicitly passing the logfile to the slaves as a
command line argument, so the logfile argument (and logging) can be
available to the slave before qfork and globals setup have completed.

Writing to the same file atomically from multiple processes requires
using CreateFile with FILE_APPEND_DATA, instead of fopen, which provides
atomicity on Unix but not on Windows.

Also changed the implementation to not reopen the logfile on every
log event, and not flushing the file on every write. Performance is
dramaticaly improved this way.
