### PR TITLE
Fix crashes when inserting large values that exceed memory set in config file

### DIFF
--- a/src/Win32_Interop/Win32_QFork.cpp
+++ b/src/Win32_Interop/Win32_QFork.cpp
@@ -1170,6 +1170,12 @@ LPVOID AllocHeapBlock(size_t size, BOOL allocateHigh) {
     }
     int contiguousBlocksToAllocate = (int)(size / g_pQForkControl->heapBlockSize);
 
+	if (contiguousBlocksToAllocate > g_pQForkControl->availableBlocksInHeap)
+	{
+		errno = ENOMEM;
+		return retPtr;
+	}
+
     size_t mapped = 0;
     int startIndex = allocateHigh ? g_pQForkControl->availableBlocksInHeap - 1 : 0;
     int endIndex = allocateHigh ? -1 : g_pQForkControl->availableBlocksInHeap;

--- a/src/Win32_Interop/Win32_QFork.cpp
+++ b/src/Win32_Interop/Win32_QFork.cpp
@@ -1170,11 +1170,10 @@ LPVOID AllocHeapBlock(size_t size, BOOL allocateHigh) {
     }
     int contiguousBlocksToAllocate = (int)(size / g_pQForkControl->heapBlockSize);
 
-	if (contiguousBlocksToAllocate > g_pQForkControl->availableBlocksInHeap)
-	{
-		errno = ENOMEM;
-		return retPtr;
-	}
+    if (contiguousBlocksToAllocate > g_pQForkControl->availableBlocksInHeap) {
+        errno = ENOMEM;
+        return retPtr;
+    }
 
     size_t mapped = 0;
     int startIndex = allocateHigh ? g_pQForkControl->availableBlocksInHeap - 1 : 0;

--- a/src/Win32_Interop/Win32_QFork.cpp
+++ b/src/Win32_Interop/Win32_QFork.cpp
@@ -1171,8 +1171,8 @@ LPVOID AllocHeapBlock(size_t size, BOOL allocateHigh) {
     int contiguousBlocksToAllocate = (int)(size / g_pQForkControl->heapBlockSize);
 
     size_t mapped = 0;
-    int startIndex = allocateHigh ? g_pQForkControl->availableBlocksInHeap - 1 : contiguousBlocksToAllocate - 1;
-    int endIndex = allocateHigh ? -1 : g_pQForkControl->availableBlocksInHeap - contiguousBlocksToAllocate + 1;
+    int startIndex = allocateHigh ? g_pQForkControl->availableBlocksInHeap - 1 : 0;
+    int endIndex = allocateHigh ? -1 : g_pQForkControl->availableBlocksInHeap;
     int direction = allocateHigh ? -1 : 1;
     int blockIndex = 0;
     int contiguousBlocksFound = 0;


### PR DESCRIPTION
Our redis instance was crashing when inserting values that exceeded the maxmemory size or when they were just large (around 30% of the maxmemorysize. We are using 10mb of maxmemorysize and would see redis crash when inserting around 3Mb values). It's pretty easy to repro the crashes.

Found one of the issues is in Win32_QFork->AllocHeapBlock when it's called with the allocateHigh set to false (This is when you try to insert a value that exceeds the maxmemorysize).
Another issue was in networking.c->readQueryFromClient and processMultibulkBuffer (these where when you try to insert a largish value that was smaller than maxmemorysize).

These commits seem to fix the problem
