### PR TITLE
Abort on OOM

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -3463,8 +3463,8 @@ void redisOutOfMemoryHandler(size_t allocation_size) {
 #else
     redisLog(REDIS_WARNING,"Out Of Memory allocating %zu bytes!",
         allocation_size);
-    redisPanic("Redis aborting for OUT OF MEMORY");
 #endif
+    redisPanic("Redis aborting for OUT OF MEMORY");
 }
 
 void redisSetProcTitle(char *title) {


### PR DESCRIPTION
It looks like https://github.com/MSOpenTech/redis/commit/62cc0e320d9afe28cc44a642d9e8f5e1c0e5d775#diff-07ce465381b20e496c6fb51bedd3491fR3105
inadvertently made the Windows side not abort when an OOM occurs.
