### PR TITLE
Workaround for getpeername() issue

### DIFF
--- a/src/Win32_Interop/win32_wsiocp.h
+++ b/src/Win32_Interop/win32_wsiocp.h
@@ -56,6 +56,7 @@ typedef struct aeSockState {
     int wreqs;
     OVERLAPPED ov_read;
     list wreqlist;
+    SOCKADDR_STORAGE remoteAddress;
 } aeSockState;
 
 typedef aeSockState * fnGetSockState(void *apistate, int fd);
@@ -68,7 +69,7 @@ typedef void fnDelSockState(void *apistate, aeSockState *sockState);
 #define CONNECT_PENDING     0x002000
 #define CLOSE_PENDING       0x004000
 
-void aeWinInit(void *state, HANDLE iocp, fnGetSockState *getSockState, fnDelSockState *delSockState);
+void aeWinInit(void *state, HANDLE iocp, fnGetSockState *getSockState, fnGetSockState *getExistingSockState, fnDelSockState *delSockState);
 void aeWinCleanup();
 
 #endif

--- a/src/Win32_Interop/win32fixes.h
+++ b/src/Win32_Interop/win32fixes.h
@@ -301,6 +301,7 @@ int aeWinSocketSend(int fd, char *buf, int len,
                     void *eventLoop, void *client, void *data, void *proc);
 int aeWinListen(int rfd, int backlog);
 int aeWinAccept(int fd, struct sockaddr *sa, socklen_t *len);
+int aeWinGetPeerName(int fd, struct sockaddr *addr, socklen_t * addrlen);
 int aeWinSocketConnect(int fd, const SOCKADDR_STORAGE *ss);
 int aeWinSocketConnectBind(int fd, const SOCKADDR_STORAGE *ss, const char* source_addr);
 

--- a/src/ae_wsiocp.c
+++ b/src/ae_wsiocp.c
@@ -90,6 +90,7 @@ aeSockState *aeGetSockState(void *apistate, int fd) {
         sockState->wreqs = 0;
         sockState->reqs = NULL;
         memset(&sockState->wreqlist, 0, sizeof(sockState->wreqlist));
+        memset(&sockState->remoteAddress, 0, sizeof(sockState->remoteAddress));
 
         if (listAddNodeHead(socklist, sockState) != NULL) {
             return sockState;
@@ -202,7 +203,7 @@ static int aeApiCreate(aeEventLoop *eventLoop) {
     state->setsize = eventLoop->setsize;
     eventLoop->apidata = state;
     /* initialize the IOCP socket code with state reference */
-    aeWinInit(state, state->iocp, aeGetSockState, aeDelSockState);
+    aeWinInit(state, state->iocp, aeGetSockState, aeGetExistingSockState, aeDelSockState);
     return 0;
 }
 

--- a/src/anet.c
+++ b/src/anet.c
@@ -646,7 +646,11 @@ int anetPeerToString(int fd, char *ip, size_t ip_len, int *port) {
     struct sockaddr_storage sa;
     socklen_t salen = sizeof(sa);
 
+#ifdef WIN32_IOCP
+    if (aeWinGetPeerName(fd,(struct sockaddr*)&sa,&salen) == -1) {
+#else
     if (getpeername(fd,(struct sockaddr*)&sa,&salen) == -1) {
+#endif
         if (port) *port = 0;
         ip[0] = '?';
         ip[1] = '\0';


### PR DESCRIPTION
getpeername() is returning invalid addresses on ipv6 sockets accepted
with AcceptEx, filling only 16 bytes of the address structure.
Providing a workaround by saving the remote address returned by
GetAcceptExSockaddrs, which is valid.
