### PR TITLE
Changed Nuget package structure to support VS 2015

### DIFF
--- a/msvs/setups/nuget/template/Redis.nuspec.template
+++ b/msvs/setups/nuget/template/Redis.nuspec.template
@@ -21,9 +21,9 @@ This package will install the Redis binaries in the default Nuget lib directory.
     <releaseNotes>The release notes are available here: https://raw.githubusercontent.com/MSOpenTech/redis/2.8/Redis%20on%20Windows%20Release%20Notes.md</releaseNotes>
   </metadata>
   <files>
-    <file src="..\signed_binaries\*.exe" target=".\" />
-    <file src="..\signed_binaries\*.pdb" target=".\" />
-    <file src="..\signed_binaries\*.conf" target=".\" />
-    <file src="..\signed_binaries\*.docx" target=".\" />
+    <file src="..\signed_binaries\*.exe" target="tools" />
+    <file src="..\signed_binaries\*.pdb" target="tools" />
+    <file src="..\signed_binaries\*.conf" target="tools" />
+    <file src="..\signed_binaries\*.docx" target="tools" />
   </files>
 </package>


### PR DESCRIPTION
I've updated the .nuspec template for nuget to move files into the tools folder. This is now the default convention used for binaries with nuget 3/VS 2015.

As the generated .nuspec file is versionned, it was not updated. It will be automatically updated during the next release.

Should fix https://github.com/MSOpenTech/redis/issues/280 

Tested on VS 2013 and VS 2015.
