### PR TITLE
Updated list of sentinel commands to use the announce-ip and announce…

### DIFF
--- a/src/Win32_Interop/Win32_CommandLine.cpp
+++ b/src/Win32_Interop/Win32_CommandLine.cpp
@@ -292,7 +292,9 @@ public:
             { "current-epoch",              &fp1 },    // sentinel current-epoch <epoch>
             { "leader-epoch",               &fp2 },    // sentinel leader-epoch [name] [epoch]
             { "known-slave",                &fp3 },    // sentinel known-slave <name> <ip> <port>
-            { "known-sentinel",             &fp4 }     // sentinel known-sentinel <name> <ip> <port> [runid]
+			{ "known-sentinel",				&fp4 },     // sentinel known-sentinel <name> <ip> <port> [runid]
+			{ "announce-ip",				&fp1 },    // sentinel announce-ip <ip>
+			{ "announce-port",				&fp1 }     // sentinel announce-port <port>
         };
     }
 


### PR DESCRIPTION
Updated the ability to redis sentinel to allow the announce-ip and announce-port configuration options for a sentinel.

The sentinel code was already created and being used but the command line wouldn't allow the option
