### PR TITLE
Add notice for VS2013 without Update 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Redis on Windows
 
 ## How to build Redis using Visual Studio
 
-You can use the free [Visual Studio Community edition](http://www.visualstudio.com/products/visual-studio-community-vs).
+You can use the free [Visual Studio Community edition](http://www.visualstudio.com/products/visual-studio-community-vs). If you use Microsoft Visual Studio 2013 (standard), make sure you have updated to Update 5, otherwise you will get a " illegal use of this type as an expression" error.
 
 - Open the solution file msvs\redisserver.sln in Visual Studio, select a build configuration (Debug or Release) and target (x64) then build.
 


### PR DESCRIPTION
Add notice to install VS2013 Update 5 to make sure it compiles properly.
