### PR TITLE
some fixes for Windows x64 version

### DIFF
--- a/src/Win32_Interop/Win32_CommandLine.cpp
+++ b/src/Win32_Interop/Win32_CommandLine.cpp
@@ -310,7 +310,7 @@ public:
         vector<string> params;
         params.push_back(argv[argStartIndex + 1]);
         vector<string> subParams = subCommands[argv[argStartIndex + 1]]->Extract(argStartIndex + 1, argc, argv);
-        for (string p : params) {
+		for (string p : subParams) {
             transform(p.begin(), p.end(), p.begin(), ::tolower);
             p = stripQuotes(p);
             params.push_back(p);
@@ -511,7 +511,6 @@ vector<string> Tokenize(string line)  {
 void ParseConfFile(string confFile, string cwd, ArgumentMap& argMap) {
     ifstream config;
     string line;
-    string value;
 
     char fullConfFilePath[MAX_PATH];
     if (PathIsRelativeA(confFile.c_str())) {

--- a/src/Win32_Interop/Win32_CommandLine.cpp
+++ b/src/Win32_Interop/Win32_CommandLine.cpp
@@ -46,7 +46,7 @@ using namespace std;
 ArgumentMap g_argMap;
 vector<string> g_pathsAccessed;
 
-string stripQuotes(string s) {
+string stripQuotes(const string& s) {
     if (s.length() >= 2) {
         if (s.at(0) == '\'' &&  s.at(s.length() - 1) == '\'') {
             if (s.length() > 2) {
@@ -199,7 +199,7 @@ public:
     dllfunctor_stdcall<int, LPCSTR, INT, LPWSAPROTOCOL_INFO, LPSOCKADDR, LPINT> f_WSAStringToAddressA =
         dllfunctor_stdcall<int, LPCSTR, INT, LPWSAPROTOCOL_INFO, LPSOCKADDR, LPINT>("ws2_32.dll", "WSAStringToAddressA");
 
-    bool IsIPAddress(string address) {
+    bool IsIPAddress(const string& address) {
         SOCKADDR_IN sockaddr4;
         sockaddr4.sin_family = AF_INET;
         SOCKADDR_IN6 sockaddr6;
@@ -457,7 +457,7 @@ std::vector<std::string> split(const std::string &s, char delim) {
     return elems;
 }
 
-vector<string> Tokenize(string line)  {
+vector<string> Tokenize(const string& line)  {
     vector<string> tokens;
     stringstream token;
 
@@ -467,7 +467,7 @@ vector<string> Tokenize(string line)  {
         return tokens;
     }
 
-    for (string::const_iterator sit = line.begin(); sit != line.end(); sit++) {
+    for (string::const_iterator sit = line.begin(); sit != line.end(); ++sit) {
         char c = *(sit);
         if (isspace(c) && token.str().length() > 0) {
             tokens.push_back(token.str());
@@ -508,7 +508,7 @@ vector<string> Tokenize(string line)  {
     return tokens;
 }
 
-void ParseConfFile(string confFile, string cwd, ArgumentMap& argMap) {
+void ParseConfFile(const string& confFile, const string& cwd, ArgumentMap& argMap) {
     ifstream config;
     string line;
 

--- a/src/Win32_Interop/Win32_CommandLine.h
+++ b/src/Win32_Interop/Win32_CommandLine.h
@@ -36,7 +36,7 @@ using namespace std;
 typedef map<string, vector<vector<string>>> ArgumentMap;
 extern ArgumentMap g_argMap;
 
-void ParseConfFile(string confFile, string cwd, ArgumentMap& argMap);
+void ParseConfFile(const string& confFile, const string& cwd, ArgumentMap& argMap);
 void ParseCommandLineArguments(int argc, char** argv);
 vector<string> GetAccessPaths();
 

--- a/src/Win32_Interop/Win32_EventLog.cpp
+++ b/src/Win32_Interop/Win32_EventLog.cpp
@@ -68,7 +68,7 @@ void RedisEventLog::UninstallEventLogSource() {
 }
 
 // sets up the registry keys required for the EventViewer message filter
-void RedisEventLog::InstallEventLogSource(string appPath) {
+void RedisEventLog::InstallEventLogSource(const string& appPath) {
     SmartRegistryHandle eventLogKey;
     if (ERROR_SUCCESS != RegOpenKeyA(HKEY_LOCAL_MACHINE, cEventLogPath.c_str(), eventLogKey)) {
         throw std::system_error(GetLastError(), system_category(), "RegOpenKey failed");
@@ -156,7 +156,7 @@ void RedisEventLog::LogMessage(LPCSTR msg, const WORD type) {
     }
 }
 
-void RedisEventLog::LogError(string msg) {
+void RedisEventLog::LogError(const string& msg) {
     try {
         if (eventLogEnabled == true) {
             stringstream ss;

--- a/src/Win32_Interop/Win32_EventLog.h
+++ b/src/Win32_Interop/Win32_EventLog.h
@@ -30,13 +30,13 @@ typedef class RedisEventLog {
 public:
     ~RedisEventLog() {}
 
-    void InstallEventLogSource(string appPath);
+    void InstallEventLogSource(const string& appPath);
     void UninstallEventLogSource();
 
     void SetEventLogIdentity(const char* identity);
 
     void LogMessage(LPCSTR msg, const WORD type);
-    void LogError(string msg);
+    void LogError(const string& msg);
 
     string GetEventLogIdentity();
     void EnableEventLog(bool enabled);

--- a/src/Win32_Interop/Win32_PThread.c
+++ b/src/Win32_Interop/Win32_PThread.c
@@ -92,8 +92,10 @@ int win32_pthread_join(pthread_t *thread, void **value_ptr) {
     switch (WaitForSingleObject(h, INFINITE)) {
         case WAIT_OBJECT_0:
             result = 0;
+			break;
         case WAIT_ABANDONED:
             result = EINVAL;
+			break;
         default:
             result = GetLastError();
     }

--- a/src/Win32_Interop/Win32_QFork.cpp
+++ b/src/Win32_Interop/Win32_QFork.cpp
@@ -510,7 +510,7 @@ StartupStatus QForkStartup() {
 
     if (g_IsForkedProcess) {
         // Child command line looks like: --QFork [QForkControlMemoryMap handle] [parent pid]
-        HANDLE QForkControlMemoryMapHandle = (HANDLE) strtoul(g_argMap[cQFork].at(0).at(0).c_str(), NULL, 10);
+        HANDLE QForkControlMemoryMapHandle = (HANDLE) strtoull(g_argMap[cQFork].at(0).at(0).c_str(), NULL, 10);
         DWORD PPID = strtoul(g_argMap[cQFork].at(0).at(1).c_str(), NULL, 10);
         return QForkChildInit(QForkControlMemoryMapHandle, PPID) ? StartupStatus::ssCHILD_EXIT : StartupStatus::ssFAILED;
     } else {

--- a/src/Win32_Interop/Win32_SmartHandle.h
+++ b/src/Win32_Interop/Win32_SmartHandle.h
@@ -56,7 +56,7 @@ public:
             throw std::runtime_error("invalid handle passed to constructor");
     }
 
-    HANDLE Assign(HANDLE h, string errorToReport)
+    HANDLE Assign(HANDLE h, const string& errorToReport)
     {
         Close();
         m_handle = h;
@@ -65,7 +65,7 @@ public:
         return h;
     }
 
-    SmartHandle(HANDLE handle, string errorToReport)
+    SmartHandle(HANDLE handle, const string& errorToReport)
     {
         Close();
         m_handle = handle;
@@ -254,7 +254,7 @@ public:
         m_handle = INVALID_HANDLE_VALUE;
     }
 
-    HANDLE Assign(HANDLE mmFile, DWORD protectionFlags, DWORD maxSizeHigh, DWORD maxSizeLow, string errorToReport)
+    HANDLE Assign(HANDLE mmFile, DWORD protectionFlags, DWORD maxSizeHigh, DWORD maxSizeLow, const string& errorToReport)
     {
         Unmap();
         m_handle = CreateFileMapping(mmFile, NULL, protectionFlags, maxSizeHigh, maxSizeLow, NULL);
@@ -269,7 +269,7 @@ public:
         return m_handle;
     }
 
-    SmartFileMapHandle(HANDLE mmFile, DWORD protectionFlags, DWORD maxSizeHigh, DWORD maxSizeLow, string errorToReport)
+    SmartFileMapHandle(HANDLE mmFile, DWORD protectionFlags, DWORD maxSizeHigh, DWORD maxSizeLow, const string& errorToReport)
     {
         m_handle = CreateFileMapping(mmFile, NULL, protectionFlags, maxSizeHigh, maxSizeLow, NULL);
         if (Invalid()) {

--- a/src/Win32_Interop/Win32_service.cpp
+++ b/src/Win32_Interop/Win32_service.cpp
@@ -115,7 +115,7 @@ private:
     }
 
 public:
-    void Write(string message) {
+    void Write(const string& message) {
         if (pipe != INVALID_HANDLE_VALUE) {
             DWORD bytesWritten = 0;
             WriteFile(pipe, message.c_str(), (DWORD)message.length(), &bytesWritten, NULL);

--- a/src/Win32_Interop/Win32_service.cpp
+++ b/src/Win32_Interop/Win32_service.cpp
@@ -345,7 +345,7 @@ VOID ServiceInstall(int argc, char ** argv) {
         SetAccessACLOnFolder(userName, folder);
         aceMessage << "\"" << folder.c_str() << "\" ";
     }
-    ServicePipeWriter::getInstance().Write(aceMessage.str().c_str());
+    ServicePipeWriter::getInstance().Write(aceMessage.str());
 
     ServicePipeWriter::getInstance().Write("Redis successfully installed as a service.");
 }

--- a/src/Win32_Interop/Win32_variadicFunctor.cpp
+++ b/src/Win32_Interop/Win32_variadicFunctor.cpp
@@ -36,7 +36,7 @@ DLLMap& DLLMap::getInstance() {
 
 DLLMap::DLLMap() { };
 
-LPVOID DLLMap::getProcAddress(string dll, string functionName)
+LPVOID DLLMap::getProcAddress(const string& dll, const string& functionName)
 {
 	if (find(dll) == end()) {
 		HMODULE mod = LoadLibraryA(dll.c_str());

--- a/src/Win32_Interop/Win32_variadicFunctor.h
+++ b/src/Win32_Interop/Win32_variadicFunctor.h
@@ -36,7 +36,7 @@ private:
 	void operator=(DLLMap const&); // Don't implement to guarantee singleton semantics
 
 public:
-	LPVOID getProcAddress(string dll, string functionName);
+	LPVOID getProcAddress(const string& dll, const string& functionName);
 	virtual ~DLLMap();
 };
 
@@ -44,7 +44,7 @@ public:
 template <typename R, typename... T>
 class dllfunctor_stdcall {
 public:
-	dllfunctor_stdcall(string dll, string function)
+	dllfunctor_stdcall(const string& dll, const string& function)
 	{
 		_f = (R(__stdcall *)(T...))DLLMap::getInstance().getProcAddress(dll, function.c_str());
 	}


### PR DESCRIPTION
[fix] bug on extracting sub-params  
[fix] string (handle value) to a unsigned 64bit number for LLP64 OS 
[fix] no-break bug in switch-case  
[remove] unnecessary casting  
[fix/minor] pass strings by const ref   
