### PR TITLE
Fix building problems in MSVS2015

### DIFF
--- a/deps/jemalloc-win/include/msvc_compat/stdint.h
+++ b/deps/jemalloc-win/include/msvc_compat/stdint.h
@@ -103,11 +103,20 @@ typedef uint64_t  uint_least64_t;
 
 // 7.18.1.3 Fastest minimum-width integer types
 typedef int8_t    int_fast8_t;
-typedef int16_t   int_fast16_t;
+#if (_MSC_VER <= 1800)
+	typedef int16_t   int_fast16_t;
+#else
+	typedef int int_fast16_t;
+#endif
+
 typedef int32_t   int_fast32_t;
 typedef int64_t   int_fast64_t;
 typedef uint8_t   uint_fast8_t;
-typedef uint16_t  uint_fast16_t;
+#if (_MSC_VER <= 1800)
+	typedef uint16_t  uint_fast16_t;
+#else
+	typedef unsigned int  uint_fast16_t;
+#endif
 typedef uint32_t  uint_fast32_t;
 typedef uint64_t  uint_fast64_t;
 

--- a/deps/lua/src/fpconv.c
+++ b/deps/lua/src/fpconv.c
@@ -37,7 +37,9 @@
 
 #ifdef _WIN32
 #define inline __inline
-#define snprintf _snprintf
+#if (_MSC_VER <= 1800)
+	#define snprintf _snprintf
+#endif
 #endif
 
 /* Lua CJSON assumes the locale is the same for all threads within a

--- a/deps/lua/src/luaconf.h
+++ b/deps/lua/src/luaconf.h
@@ -750,7 +750,9 @@ union luai_Cast { double l_d; long l_l; };
 
 
 #ifdef _WIN32
-#define snprintf _snprintf
+#if (_MSC_VER <= 1800)
+	#define snprintf _snprintf
+#endif
 #endif
 
 

--- a/src/Win32_Interop/Win32_FDAPI.h
+++ b/src/Win32_Interop/Win32_FDAPI.h
@@ -37,6 +37,7 @@ typedef unsigned long nfds_t;
 #include <WinSock2.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <sys/stat.h>
 
 // Including a version of this file modified to eliminate prototype
 // definitions not removed by INCL_WINSOCK_API_PROTOTYPES
@@ -225,14 +226,10 @@ extern int FDAPI_fileno(FILE *file);
 #define fclose(File)                FDAPI_fclose(File)
 #define setmode(fd,mode)            FDAPI_setmode(fd,mode)
 #define fwrite(Str,Size,Count,File) FDAPI_fwrite(Str,Size,Count,File)
-#if (_MSC_VER <= 1800)
-	#define fileno(File)            FDAPI_fileno(File)
-	#define _INC_STAT_INL
-	#define fstat(fd,buffer)        fdapi_fstat64(fd,buffer)
-#else
-	#define fileno(File)            _fileno(File)
-#endif
+#define fileno(File)                FDAPI_fileno(File)
 
+#define _INC_STAT_INL
+#define fstat(fd,buffer)            fdapi_fstat64(fd,buffer)
 #endif
 
 #ifdef __cplusplus

--- a/src/Win32_Interop/Win32_FDAPI.h
+++ b/src/Win32_Interop/Win32_FDAPI.h
@@ -225,10 +225,14 @@ extern int FDAPI_fileno(FILE *file);
 #define fclose(File)                FDAPI_fclose(File)
 #define setmode(fd,mode)            FDAPI_setmode(fd,mode)
 #define fwrite(Str,Size,Count,File) FDAPI_fwrite(Str,Size,Count,File)
-#define fileno(File)                FDAPI_fileno(File)
+#if (_MSC_VER <= 1800)
+	#define fileno(File)            FDAPI_fileno(File)
+	#define _INC_STAT_INL
+	#define fstat(fd,buffer)        fdapi_fstat64(fd,buffer)
+#else
+	#define fileno(File)            _fileno(File)
+#endif
 
-#define _INC_STAT_INL
-#define fstat(fd,buffer)            fdapi_fstat64(fd,buffer)
 #endif
 
 #ifdef __cplusplus

--- a/src/Win32_Interop/Win32_Time.h
+++ b/src/Win32_Interop/Win32_Time.h
@@ -25,9 +25,12 @@
 #ifndef WIN32_INTEROP_TIME_H
 #define WIN32_INTEROP_TIME_H
 
+#if (_MSC_VER > 1800)
+#include <corecrt.h>
+#endif
 #include <stdint.h>
-
 #define gettimeofday gettimeofday_highres
+
 
 void     InitTimeFunctions();
 uint64_t GetHighResRelativeTime(double scale);

--- a/src/redis.h
+++ b/src/redis.h
@@ -1087,7 +1087,7 @@ void freeClientsInAsyncFreeQueue(void);
 void asyncCloseClientOnOutputBufferLimitReached(redisClient *c);
 int getClientType(redisClient *c);
 int getClientTypeByName(char *name);
-char *getClientTypeName(int class);
+char *getClientTypeName(int name);
 void flushSlavesOutputBuffers(void);
 void disconnectSlaves(void);
 int listenToPort(int port, int *fds, int *count);

--- a/src/redis.h
+++ b/src/redis.h
@@ -1087,7 +1087,7 @@ void freeClientsInAsyncFreeQueue(void);
 void asyncCloseClientOnOutputBufferLimitReached(redisClient *c);
 int getClientType(redisClient *c);
 int getClientTypeByName(char *name);
-char *getClientTypeName(int name);
+char *getClientTypeName(int IF_WIN32(_class,class));
 void flushSlavesOutputBuffers(void);
 void disconnectSlaves(void);
 int listenToPort(int port, int *fds, int *count);


### PR DESCRIPTION
Fix #409 (and probably #382 )

1) fix incompatibility typdefs: 'int_fast16_t' and 'uint_fast16_t'
between header files "msvc_compat/stdint.h" and "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\stdint.h"

2) fix "Macro definition of snprintf conflicts" in "deps/lua/src/fpconv.c" and " deps/lua/src/luaconf.h"

3) fix "fileno" defs in " src/Win32_Interop/Win32_FDAPI.h" (otherwise it crashes when loading dump.rdb)

4) fix the preserved word "class" in function declaration in "src/redis.h"

5) fix compling error for file " src/Win32_Interop/Win32_Time.h" 
