### PR TITLE
Fix issue #458. Update msvs documentation to correct maxmemory-policy

### DIFF
--- a/msvs/setups/documentation/redis.windows-service.conf
+++ b/msvs/setups/documentation/redis.windows-service.conf
@@ -267,7 +267,7 @@ slave-read-only yes
 repl-diskless-sync no
 
 # When diskless replication is enabled, it is possible to configure the delay
-# the server waits in order to spawn the child that trnasfers the RDB via socket
+# the server waits in order to spawn the child that transfers the RDB via socket
 # to the slaves.
 #
 # This is important since once the transfer starts, it is not possible to serve
@@ -488,7 +488,7 @@ slave-priority 100
 #
 # The default is:
 #
-# maxmemory-policy volatile-lru
+# maxmemory-policy noeviction
 
 # LRU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can select as well the sample
@@ -781,7 +781,7 @@ slowlog-max-len 128
 # By default latency monitoring is disabled since it is mostly not needed
 # if you don't have latency issues, and collecting data has a performance
 # impact, that while very small, can be measured under big load. Latency
-# monitoring can easily be enalbed at runtime using the command
+# monitoring can easily be enabled at runtime using the command
 # "CONFIG SET latency-monitor-threshold <milliseconds>" if needed.
 latency-monitor-threshold 0
 

--- a/msvs/setups/documentation/redis.windows.conf
+++ b/msvs/setups/documentation/redis.windows.conf
@@ -267,7 +267,7 @@ slave-read-only yes
 repl-diskless-sync no
 
 # When diskless replication is enabled, it is possible to configure the delay
-# the server waits in order to spawn the child that trnasfers the RDB via socket
+# the server waits in order to spawn the child that transfers the RDB via socket
 # to the slaves.
 #
 # This is important since once the transfer starts, it is not possible to serve
@@ -488,7 +488,7 @@ slave-priority 100
 #
 # The default is:
 #
-# maxmemory-policy volatile-lru
+# maxmemory-policy noeviction
 
 # LRU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can select as well the sample
@@ -781,7 +781,7 @@ slowlog-max-len 128
 # By default latency monitoring is disabled since it is mostly not needed
 # if you don't have latency issues, and collecting data has a performance
 # impact, that while very small, can be measured under big load. Latency
-# monitoring can easily be enalbed at runtime using the command
+# monitoring can easily be enabled at runtime using the command
 # "CONFIG SET latency-monitor-threshold <milliseconds>" if needed.
 latency-monitor-threshold 0
 


### PR DESCRIPTION
Update msvs documentation to correct maxmemory-policy (as per 3.0 release notes). Fix other typos.
