### PR TITLE
Fixes issue with master killing client connections while redis is write

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -895,7 +895,7 @@ void sendReplyToClient(aeEventLoop *el, int fd, void *privdata, int mask) {
         } else {
             o = listNodeValue(ln);
             objlen = (int)sdslen(o->ptr);
-            objmem = zmalloc_size_sds(o->ptr);
+            objmem = getStringObjectSdsUsedMemory(o);
 
             if (objlen == 0) {
                 listDelNode(c->reply,ln);


### PR DESCRIPTION
Fixes issue with master killing client connections while redis is under high write loads

reply_bytes was being wrapped to huge values,
e.g.omem=18446744073709551601 causing redis to close the connection as it
thought the client buffer limit had been exceeded.

See https://github.com/antirez/redis/blob/3.0/src/networking.c#L827