### PR TITLE
Fixes client buffer size underflow

### DIFF
--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -121,8 +121,6 @@
 #include <ctype.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/ioctl.h>
-#include <unistd.h>
 #include "linenoise.h"
 
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
@@ -1336,14 +1334,22 @@ int linenoiseHistorySetMaxLen(int len) {
 /* Save the history in the specified file. On success 0 is returned
  * otherwise -1 is returned. */
 int linenoiseHistorySave(const char *filename) {
+#ifndef _WIN32
     mode_t old_umask = umask(S_IXUSR|S_IRWXG|S_IRWXO);
+#endif
     FILE *fp;
     int j;
 
+#ifdef _WIN32
+    fp = fopen(filename,"wb");
+#else
     fp = fopen(filename,"w");
     umask(old_umask);
+#endif
     if (fp == NULL) return -1;
+#ifndef _WIN32
     chmod(filename,S_IRUSR|S_IWUSR);
+#endif
     for (j = 0; j < history_len; j++)
         fprintf(fp,"%s\n",history[j]);
     fclose(fp);

--- a/src/debugmacro.h
+++ b/src/debugmacro.h
@@ -31,6 +31,11 @@
  */
 
 #include <stdio.h>
+
+#ifdef _WIN32
+#define __func__ __FUNCTION__
+#endif
+
 #define D(...)                                                               \
     do {                                                                     \
         FILE *fp = fopen("/tmp/log.txt","a");                                \

--- a/src/networking.c
+++ b/src/networking.c
@@ -990,7 +990,7 @@ int writeToClient(int fd, client *c, int handler_installed) {
         } else {
             o = listNodeValue(ln);
             objlen = (int)sdslen(o->ptr);
-            objmem = sdsZmallocSize(o->ptr);
+            objmem = getStringObjectSdsUsedMemory(o);
 
             if (objlen == 0) {
                 listDelNode(c->reply,ln);

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -158,11 +158,14 @@ void rdbCheckSetError(const char *fmt, ...) {
 /* During RDB check we setup a special signal handler for memory violations
  * and similar conditions, so that we can log the offending part of the RDB
  * if the crash is due to broken content. */
+#ifdef _WIN32
+void rdbCheckHandleCrash(int sig) {
+#else
 void rdbCheckHandleCrash(int sig, siginfo_t *info, void *secret) {
-    UNUSED(sig);
     UNUSED(info);
     UNUSED(secret);
-
+#endif
+    UNUSED(sig);
     rdbCheckError("Server crash checking the specified RDB file!");
     exit(1);
 }


### PR DESCRIPTION
Fixes client buffer size underflow due to miscalculation of object memory size.

Client buffer size increases by the value of getStringObjectSdsUsedMemory(o), while decreases by the value of sdsZmallocSize(o->ptr). The mismatch might cause client buffer size underflow and consequent connection close as the limit of client buffer size is exceeded.

Refer to https://github.com/antirez/redis/blob/3.2/src/networking.c