### PR TITLE
AUTH immediately after creating a connection

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -412,6 +412,11 @@ static client createClient(char *cmd, size_t len, client from) {
         c->obuf = sdscatlen(c->obuf, buf, len);
         free(buf);
         c->prefix_pending++;
+
+        //Try sending AUTH immediately
+        int result = WSIOCP_SocketSend(c->context->fd, (char*)c->obuf,
+            (int)(sdslen(c->obuf)),
+            config.el, c, NULL, writeHandlerDone);
     }
 
     /* If a DB number different than zero is selected, prefix our request


### PR DESCRIPTION
While using redis-benchmark with more that one client for eg. -c 500, it would first create 500 connections and then authenticate them by sending AUTH command over the wire. 

This creates an issue while trying to benchmark Redis endpoints (like Azure Redis) that implements DDOS attack prevention by dropping  connections in an event of high number of unauthenticated clients.

With this pull request I am proposing to send AUTH command immediately after a connection has been created by redis-benchmark to improve this scenario.
