### PR TITLE
Fix a fatal bug caused by logic default in winxp(windows version<6.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ msvs/BuildRelease
 msvs/Documentation
 tests/tmp/
 
+*.db
+*.opendb
+api/

--- a/src/Win32_Interop/Win32_FDAPI.cpp
+++ b/src/Win32_Interop/Win32_FDAPI.cpp
@@ -671,7 +671,7 @@ int FDAPI_poll(struct pollfd *fds, nfds_t nfds, int timeout) {
 
             nfds_t i;
             for (i = 0; i < nfds; i++) {
-                if (fds[i].fd == INVALID_SOCKET) {
+                if (pollCopy[i].fd == INVALID_SOCKET) {
                     continue;
                 }
                 if (fds[i].fd >= FD_SETSIZE) {

--- a/src/Win32_Interop/Win32_FDAPI.cpp
+++ b/src/Win32_Interop/Win32_FDAPI.cpp
@@ -1001,28 +1001,7 @@ int FDAPI_fileno(FILE *file) {
 }
 
 int FDAPI_select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout) {
-    try {
-        if (readfds != NULL) {
-            for (u_int r = 0; r < readfds->fd_count; r++) {
-                readfds->fd_array[r] = RFDMap::getInstance().lookupSocket((RFD) readfds->fd_array[r]);
-            }
-        }
-        if (writefds != NULL) {
-            for (u_int r = 0; r < writefds->fd_count; r++) {
-                writefds->fd_array[r] = RFDMap::getInstance().lookupSocket((RFD) writefds->fd_array[r]);
-            }
-        }
-        if (exceptfds != NULL) {
-            for (u_int r = 0; r < exceptfds->fd_count; r++) {
-                exceptfds->fd_array[r] = RFDMap::getInstance().lookupSocket((RFD) exceptfds->fd_array[r]);
-            }
-        }
-
-        return f_select(nfds, readfds, writefds, exceptfds, timeout);
-    } CATCH_AND_REPORT();
-
-    errno = EBADF;
-    return SOCKET_ERROR;
+    return f_select(nfds, readfds, writefds, exceptfds, timeout);
 }
 
 u_int FDAPI_ntohl(u_int netlong){

--- a/src/Win32_Interop/Win32_FDAPI.cpp
+++ b/src/Win32_Interop/Win32_FDAPI.cpp
@@ -674,7 +674,7 @@ int FDAPI_poll(struct pollfd *fds, nfds_t nfds, int timeout) {
                 if (fds[i].fd == INVALID_SOCKET) {
                     continue;
                 }
-                if (pollCopy[i].fd >= FD_SETSIZE) {
+                if (fds[i].fd >= FD_SETSIZE) {
                     errno = EINVAL;
                     return -1;
                 }


### PR DESCRIPTION
This bug results in client cannot connect to server using function `FDAPI_select` invoked by `FDAPI_poll`.
The function `FDAPI_select` should not do any redundant map actions,because `FDAPI_poll` has mapped fd to socket at `line 635,file Win32_FDAPI.cpp`.